### PR TITLE
Added Authorea in browser-based editors list

### DIFF
--- a/markdown-editors-browserBased.yml
+++ b/markdown-editors-browserBased.yml
@@ -14,6 +14,11 @@
 # - http://pastebin.com/j7Pjq1QT
 # - https://github.com/search?q=markdown
 ---
+Authorea:
+  about: A collaborative typewriter for academia
+  platform: browser
+  website: https://www.authorea.com/
+
 Dillinger:
   platform: browser
   website: http://dillinger.io/


### PR DESCRIPTION
Authorea is a very domain-specific editor, and it also supports LaTeX, but I thought it should appear in this list.
